### PR TITLE
remove setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[tool:pytest]
-norecursedirs = integration_tests


### PR DESCRIPTION
pytest not used; file useless

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deletes `setup.cfg`, removing the obsolete pytest `norecursedirs` configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df2173a8f4b9c45330de6bc73132be60f1ff5aec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->